### PR TITLE
Add GitHub Actions CI workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,10 @@ concurrency:
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   python:
     name: lint-python
@@ -63,4 +67,29 @@ jobs:
           python3 -m pip install "reuse==6.2.0"
 
       - name: Run REUSE lint
-        run: reuse lint
+        run: |
+          set -euo pipefail
+
+          output="$(mktemp)"
+          if reuse lint >"${output}" 2>&1; then
+            cat "${output}"
+            exit 0
+          fi
+
+          cat "${output}"
+
+          # The public GitHub mirror excludes internal/ and .gitlab-ci.yml, so
+          # the proprietary license text can be unused here while still being
+          # used by the internal GitLab source tree.
+          if grep -Fxq "* Unused licenses: LicenseRef-NvidiaProprietary" "${output}" &&
+             grep -Fxq "* Bad licenses: 0" "${output}" &&
+             grep -Fxq "* Deprecated licenses: 0" "${output}" &&
+             grep -Fxq "* Licenses without file extension: 0" "${output}" &&
+             grep -Fxq "* Missing licenses: 0" "${output}" &&
+             grep -Fxq "* Read errors: 0" "${output}" &&
+             grep -Fxq "* Invalid SPDX License Expressions: 0" "${output}"; then
+            echo "Allowing unused LicenseRef-NvidiaProprietary in the public mirror."
+            exit 0
+          fi
+
+          exit 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ name: Lint
 # public repo, self-hosted PR execution should move to its trusted branch flow.
 on:
   push:
-    branches: ["**"]
+    branches: [main, master]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+name: Lint
+
+# Ordinary private-repo triggers for now. When copy-pr-bot is enabled for the
+# public repo, self-hosted PR execution should move to its trusted branch flow.
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  python:
+    name: lint-python
+    runs-on: [self-hosted, omni-dreams]
+    container:
+      image: python:3.12-slim
+    steps:
+      - name: Show Python version
+        run: python3 --version
+
+      - name: Install ruff
+        run: |
+          set -euo pipefail
+          python3 -m pip install --upgrade pip
+          python3 -m pip install ruff
+
+      - name: Repo-level Python lint placeholder
+        run: echo "No additional files to lint at repo level"
+
+  reuse:
+    name: lint-reuse
+    runs-on: [self-hosted, omni-dreams]
+    container:
+      image: python:3.12-slim
+    steps:
+      - name: Install git for checkout
+        run: |
+          set -euo pipefail
+          apt-get update
+          apt-get install -y --no-install-recommends ca-certificates git
+          rm -rf /var/lib/apt/lists/*
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Mark checkout as safe for git
+        run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+
+      - name: Install REUSE
+        run: |
+          set -euo pipefail
+          python3 -m pip install --upgrade pip
+          python3 -m pip install "reuse==6.2.0"
+
+      - name: Run REUSE lint
+        run: reuse lint

--- a/.github/workflows/post-training.yml
+++ b/.github/workflows/post-training.yml
@@ -7,7 +7,7 @@ name: Post-Training
 # public repo, self-hosted PR execution should move to its trusted branch flow.
 on:
   push:
-    branches: ["**"]
+    branches: [main, master]
     paths:
       - "samples/post-training/**"
       - "post-training/**"

--- a/.github/workflows/post-training.yml
+++ b/.github/workflows/post-training.yml
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+name: Post-Training
+
+# Ordinary private-repo triggers for now. When copy-pr-bot is enabled for the
+# public repo, self-hosted PR execution should move to its trusted branch flow.
+on:
+  push:
+    branches: ["**"]
+    paths:
+      - "samples/post-training/**"
+      - "post-training/**"
+      - ".github/workflows/post-training.yml"
+  pull_request:
+    paths:
+      - "samples/post-training/**"
+      - "post-training/**"
+      - ".github/workflows/post-training.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  script-tests:
+    name: post-training-script-tests
+    runs-on: [self-hosted, omni-dreams]
+    container:
+      image: python:3.10-slim
+    steps:
+      - name: Install git for checkout
+        run: |
+          set -euo pipefail
+          apt-get update
+          apt-get install -y --no-install-recommends ca-certificates git
+          rm -rf /var/lib/apt/lists/*
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Mark checkout as safe for git
+        run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+
+      - name: Install test dependencies
+        run: |
+          set -euo pipefail
+          python --version
+          python -m pip install --upgrade pip
+          python -m pip install "pytest>=9.0.3,<10"
+
+      - name: Run script tests
+        run: |
+          set -euo pipefail
+          python -m pytest \
+            samples/post-training/tests/test_setup_env.py \
+            samples/post-training/tests/test_prepare.py \
+            samples/post-training/tests/test_torchrun_smoke.py \
+            samples/post-training/tests/test_smoke_test_slurm.py \
+            samples/post-training/tests/test_triton_per_rank_wrap.py \
+            samples/post-training/tests/test_checkpoint_setup_consistency.py
+
+  uv-sync:
+    name: post-training-uv-sync
+    runs-on: [self-hosted, omni-dreams]
+    container:
+      image: python:3.10-slim
+    env:
+      UV_CACHE_DIR: ${{ github.workspace }}/.cache/uv
+    steps:
+      - name: Install git for checkout
+        run: |
+          set -euo pipefail
+          apt-get update
+          apt-get install -y --no-install-recommends ca-certificates git
+          rm -rf /var/lib/apt/lists/*
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Mark checkout as safe for git
+        run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+
+      - name: Install uv
+        run: |
+          set -euo pipefail
+          python --version
+          python -m pip install --upgrade pip
+          python -m pip install "uv==0.10.2"
+
+      - name: Check post-training lockfile
+        working-directory: post-training
+        run: |
+          set -euo pipefail
+          uv --version
+          uv lock --check --offline
+          uv sync --extra=cu128 --locked --dry-run --offline
+
+  full-setup:
+    name: post-training-full-setup
+    runs-on: [self-hosted, omni-dreams]
+    container:
+      image: python:3.10-slim
+    timeout-minutes: 240
+    env:
+      CUDA_EXTRA: cu128
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+    steps:
+      - name: Install git for checkout
+        run: |
+          set -euo pipefail
+          apt-get update
+          apt-get install -y --no-install-recommends ca-certificates git
+          rm -rf /var/lib/apt/lists/*
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Mark checkout as safe for git
+        run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+
+      - name: Install uv
+        run: |
+          set -euo pipefail
+          python --version
+          python -m pip install --upgrade pip
+          python -m pip install "uv==0.10.2"
+
+      - name: Run full setup smoke
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${HF_TOKEN:-}" ]]; then
+            echo "ERROR: HF_TOKEN GitHub Actions secret is required for post-training full setup." >&2
+            exit 1
+          fi
+
+          export OMNI_CACHE_DIR="${GITHUB_WORKSPACE}/.cache/omni-dreams"
+          export UV_CACHE_DIR="${GITHUB_WORKSPACE}/.cache/uv"
+          export UV_TOOL_DIR="${OMNI_CACHE_DIR}/uv-tools"
+          export UV_PYTHON_INSTALL_DIR="${OMNI_CACHE_DIR}/uv-python"
+          export PIP_CACHE_DIR="${OMNI_CACHE_DIR}/pip"
+          export TMPDIR="/tmp/omni-dreams-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          export OMNI_MIN_SETUP_FREE_GB=0
+          export OMNI_MIN_WORKTREE_FREE_GB=0
+
+          mkdir -p "${OMNI_CACHE_DIR}/huggingface" "${UV_CACHE_DIR}" "${TMPDIR}"
+          printf '%s' "${HF_TOKEN}" > "${OMNI_CACHE_DIR}/huggingface/token"
+          chmod 600 "${OMNI_CACHE_DIR}/huggingface/token"
+
+          echo "Using CUDA extra: ${CUDA_EXTRA}"
+          echo "Using cache dir:   ${OMNI_CACHE_DIR}"
+          echo "Using tmp dir:     ${TMPDIR}"
+          uv --version
+
+          cd post-training
+          uv lock --check --offline
+          uv sync --extra "${CUDA_EXTRA}" --locked
+          cd "${GITHUB_WORKSPACE}"
+
+          bash samples/post-training/setup_env.sh --cache-dir "${OMNI_CACHE_DIR}"
+          source samples/post-training/_env.sh
+
+          test -x post-training/.venv/bin/python
+          test -d post-training/data/video
+          test -d post-training/data/hdmap
+          test -d post-training/data/caption
+          test -f "${OMNI_CACHE_DIR}/huggingface/token"
+
+          require_any_path() {
+            local label="$1"
+            local root="$2"
+            local pattern="$3"
+
+            if ! find "${root}" -path "${pattern}" -print -quit | grep -q .; then
+              echo "ERROR: Missing expected ${label} under ${root} matching ${pattern}" >&2
+              exit 1
+            fi
+          }
+
+          require_any_path \
+            "single-view distilled checkpoint" \
+            "${HF_HOME}/hub/models--nvidia--omni-dreams-models/snapshots" \
+            "*/single_view/distilled/*_model.pt"
+          require_any_path \
+            "Cosmos Predict2 tokenizer" \
+            "${HF_HOME}/hub/models--nvidia--Cosmos-Predict2-2B-Video2World/snapshots" \
+            "*/tokenizer/tokenizer.pth"
+          require_any_path \
+            "staged scene video symlink" \
+            "${GITHUB_WORKSPACE}/post-training/data/video" \
+            "*.mp4"
+
+          echo "Post-training full setup completed."
+          du -sh "${OMNI_CACHE_DIR}" post-training/.venv post-training/data || true
+
+      - name: Clean full setup outputs
+        if: always()
+        run: |
+          rm -rf \
+            "${GITHUB_WORKSPACE}/.cache" \
+            "${GITHUB_WORKSPACE}/post-training/.venv" \
+            "${GITHUB_WORKSPACE}/post-training/data" \
+            "/tmp/omni-dreams-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"

--- a/.github/workflows/post-training.yml
+++ b/.github/workflows/post-training.yml
@@ -26,6 +26,10 @@ concurrency:
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   script-tests:
     name: post-training-script-tests


### PR DESCRIPTION
This adds repo lint and post-training workflows that run on the self-hosted
omni-dreams runner in job containers. The post-training workflow covers the
lightweight script tests, offline uv lock/sync checks, and the full setup smoke
test gated by the HF_TOKEN repository secret.