### PR TITLE
fix: Restore num_frame_per_block=24 and max_latent_frames_per_gpu=24 for TEACHER_COSMOS2_2B_HDMAP_VAE

### DIFF
--- a/post-training/omnidreams/experiments/causal/release.py
+++ b/post-training/omnidreams/experiments/causal/release.py
@@ -188,8 +188,8 @@ TEACHER_COSMOS2_2B_HDMAP_VAE: LazyDict = LazyDict(
         model=dict(
             config=dict(
                 # Bidirectional teacher: full-block (state_t == num_frame_per_block).
-                # num_frame_per_block=24,
-                # max_latent_frames_per_gpu=24,
+                num_frame_per_block=24,
+                max_latent_frames_per_gpu=24,
                 state_t=24,
                 fsdp_shard_size=8,
                 shift=5,


### PR DESCRIPTION
## Summary
In post-training/omnidreams/experiments/causal/release.py, the TEACHER_COSMOS2_2B_HDMAP_VAE experiment config has num_frame_per_block and max_latent_frames_per_gpu commented out at lines 191-192. The resolved config therefore falls back to the CausalJointCosmosModelConfig default of num_frame_per_block=1.

Fixes #8
