### PR TITLE
docs: Flag Experiment 3 memory pressure and recommend cu128 over cu130 in post-training docs

### DIFF
--- a/samples/post-training/QUICKSTART.md
+++ b/samples/post-training/QUICKSTART.md
@@ -11,10 +11,12 @@ rented Hopper or A100 box.
   with driver 570.148.08 and CUDA 12.8. Smaller `NPROC` values are not
   supported by the released configs.
   Experiment 3 (self-forcing DMD distillation) is the memory-tightest smoke
-  recipe and runs near the 80 GB HBM ceiling on 8x H100 80 GB nodes. Use the
-  documented `uv sync --extra=cu128` install path; DeviceMonitor observed
-  `peak_gpu_mem_reserved` around 71 GB with `cu128` versus 75 GB with `cu130`,
-  and the `cu130` stack can OOM while saving the iteration-50 checkpoint.
+  recipe and runs near the 80 GB HBM ceiling on 8x H100 80 GB nodes. Current
+  `main` reclaims the CUDA allocator cache before the DCP save and is expected
+  to restore the save-time headroom needed to avoid the checkpoint-save OOM.
+  For older revisions or constrained environments, `cu128` remains a
+  lower-memory fallback: DeviceMonitor observed `peak_gpu_mem_reserved` around
+  71 GB with `cu128` versus 75 GB with `cu130`.
 * At least 150 GB of free disk for dependencies, Hugging Face caches, dataset
   staging, Triton caches, and training output. 200 GB or more is recommended.
   `setup_env.sh` enforces a 150 GB cache preflight and a 20 GB worktree

--- a/samples/post-training/QUICKSTART.md
+++ b/samples/post-training/QUICKSTART.md
@@ -10,6 +10,11 @@ rented Hopper or A100 box.
   (CUDA 12.8.1 compatible). The flow has been tested on 8x H100 80 GB HBM3
   with driver 570.148.08 and CUDA 12.8. Smaller `NPROC` values are not
   supported by the released configs.
+  Experiment 3 (self-forcing DMD distillation) is the memory-tightest smoke
+  recipe and runs near the 80 GB HBM ceiling on 8x H100 80 GB nodes. Use the
+  documented `uv sync --extra=cu128` install path; DeviceMonitor observed
+  `peak_gpu_mem_reserved` around 71 GB with `cu128` versus 75 GB with `cu130`,
+  and the `cu130` stack can OOM while saving the iteration-50 checkpoint.
 * At least 150 GB of free disk for dependencies, Hugging Face caches, dataset
   staging, Triton caches, and training output. 200 GB or more is recommended.
   `setup_env.sh` enforces a 150 GB cache preflight and a 20 GB worktree

--- a/samples/post-training/README.md
+++ b/samples/post-training/README.md
@@ -9,10 +9,12 @@ dataset, composed against the `post-training/` release tree.
 > The supported minimum post-training launch uses 8 GPUs (`NPROC=8` on a
 > single node). Smaller `NPROC` values are unsupported and the launcher fails
 > early before starting `torchrun`.
-> Experiment 3 is the memory-tightest recipe on 8x H100 80 GB nodes: prefer
-> the documented `cu128` install path, where DeviceMonitor reserved-memory
-> peaks were about 71 GB versus 75 GB with `cu130`; the `cu130` stack can OOM
-> during the iteration-50 checkpoint save.
+> Experiment 3 is the memory-tightest recipe on 8x H100 80 GB nodes. Current
+> `main` reclaims the CUDA allocator cache before the DCP save and is expected
+> to restore the save-time headroom needed to avoid the checkpoint-save OOM.
+> For older revisions or constrained environments, `cu128` remains a
+> lower-memory fallback: DeviceMonitor reserved-memory peaks were about 71 GB
+> versus 75 GB with `cu130`.
 > Plan for at least 150 GB of free disk, with 200 GB or more recommended.
 > `setup_env.sh` and `torchrun_smoke.sh` run disk preflights before the
 > expensive setup and launch phases.

--- a/samples/post-training/README.md
+++ b/samples/post-training/README.md
@@ -9,6 +9,10 @@ dataset, composed against the `post-training/` release tree.
 > The supported minimum post-training launch uses 8 GPUs (`NPROC=8` on a
 > single node). Smaller `NPROC` values are unsupported and the launcher fails
 > early before starting `torchrun`.
+> Experiment 3 is the memory-tightest recipe on 8x H100 80 GB nodes: prefer
+> the documented `cu128` install path, where DeviceMonitor reserved-memory
+> peaks were about 71 GB versus 75 GB with `cu130`; the `cu130` stack can OOM
+> during the iteration-50 checkpoint save.
 > Plan for at least 150 GB of free disk, with 200 GB or more recommended.
 > `setup_env.sh` and `torchrun_smoke.sh` run disk preflights before the
 > expensive setup and launch phases.


### PR DESCRIPTION
## Summary
Experiment 3 (self-forcing DMD distillation) is the most memory-intensive of the three sample smoke recipes and exhausts HBM on an 8xH100 80GB node, OOMing while saving the iteration-50 checkpoint. The maintainer (jmccaffrey-nv) filed the issue and explicitly named two impacted docs: the QUICKSTART.md Prerequisites bullet and the README.md supported-minimum note, neither of which flags E3 as a special case.

Fixes #4
